### PR TITLE
Add `long_description` and `long_description_content_type` to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,6 +64,8 @@ setup(
     name='neon-api-proxy',
     version=version,
     description='Neon Proxy for external API Calls',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     url='https://github.com/NeonGeckoCom/neon_api_proxy',
     author='Neongecko',
     author_email='developers@neon.ai',


### PR DESCRIPTION
# Description
Fix description handling in setup.py

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
https://github.com/NeonGeckoCom/neon_api_proxy/actions/runs/5274318135