### PR TITLE
Update W|A and OWM wrappers to match upstream APIs

### DIFF
--- a/neon_api_proxy/client/open_weather_map.py
+++ b/neon_api_proxy/client/open_weather_map.py
@@ -104,6 +104,9 @@ def _make_api_call(lat: Union[str, float], lng: Union[str, float],
     except JSONDecodeError:
         data = {"error": "Error decoding response",
                 "response": resp}
+    if data.get('cod') == "400":
+        # Backwards-compat. Put error response under `error` key
+        data["error"] = data.get("message")
     if data.get('cod'):
         data['cod'] = str(data['cod'])
         # TODO: Handle failures

--- a/neon_api_proxy/controller.py
+++ b/neon_api_proxy/controller.py
@@ -89,8 +89,9 @@ class NeonAPIProxyController:
             api_key = self.config.get(item, {}).get("api_key") if self.config \
                 else None
             try:
-                if api_key is None:
-                    LOG.warning(f"No API key for {item} in {self.config}")
+                if api_key is None and item != 'api_test_endpoint':
+                    LOG.warning(f"No API key for {item} in "
+                                f"{list(self.config.keys())}")
                 service_mapping[item] = \
                     service_class_mapping[item](api_key=api_key)
             except Exception as e:

--- a/neon_api_proxy/services/owm_api.py
+++ b/neon_api_proxy/services/owm_api.py
@@ -61,7 +61,7 @@ class OpenWeatherAPI(CachedAPI):
         lng = kwargs.get("lng", kwargs.get("lon"))
         api = kwargs.get('api') or "onecall"
         lang = kwargs.get('lang') or "en"
-        units = "metric" if kwargs.get("units", kwargs.get("unit")) == "metric" else "imperial"
+        units = "metric" if kwargs.get("units") == "metric" else "imperial"
 
         if not all((lat, lng, units)):
             return {"status_code": -1,
@@ -88,7 +88,7 @@ class OpenWeatherAPI(CachedAPI):
         except AssertionError as e:
             raise ValueError(e)
         if api != "onecall":
-            log_deprecation(f"`{api}` was requested but only `onecall` "
+            log_deprecation(f"{api} was requested but only `onecall` "
                             f"is supported", "1.0.0")
             api = "onecall"
         assert units in ("metric", "imperial", "standard")

--- a/neon_api_proxy/services/owm_api.py
+++ b/neon_api_proxy/services/owm_api.py
@@ -74,7 +74,8 @@ class OpenWeatherAPI(CachedAPI):
                     "content": repr(e),
                     "encoding": None}
         if not resp.ok:
-            LOG.error(f"Bad response code: {resp.status_code}")
+            LOG.error(f"Bad response code: {resp.status_code}: "
+                      f"content={resp.content}")
         return {"status_code": resp.status_code,
                 "content": resp.content,
                 "encoding": resp.encoding}

--- a/neon_api_proxy/services/owm_api.py
+++ b/neon_api_proxy/services/owm_api.py
@@ -61,7 +61,7 @@ class OpenWeatherAPI(CachedAPI):
         lng = kwargs.get("lng", kwargs.get("lon"))
         api = kwargs.get('api') or "onecall"
         lang = kwargs.get('lang') or "en"
-        units = "metric" if kwargs.get("units") == "metric" else "imperial"
+        units = "metric" if kwargs.get("units", kwargs.get("unit")) == "metric" else "imperial"
 
         if not all((lat, lng, units)):
             return {"status_code": -1,
@@ -88,7 +88,7 @@ class OpenWeatherAPI(CachedAPI):
         except AssertionError as e:
             raise ValueError(e)
         if api != "onecall":
-            log_deprecation(f"{api} was requested but only `onecall` "
+            log_deprecation(f"`{api}` was requested but only `onecall` "
                             f"is supported", "1.0.0")
             api = "onecall"
         assert units in ("metric", "imperial", "standard")

--- a/neon_api_proxy/services/owm_api.py
+++ b/neon_api_proxy/services/owm_api.py
@@ -82,6 +82,11 @@ class OpenWeatherAPI(CachedAPI):
 
     def _get_api_response(self, lat: str, lng: str, units: str,
                           api: str = "onecall", lang: str = "en") -> Response:
+        try:
+            assert isinstance(float(lat), float), f"Invalid latitude: {lat}"
+            assert isinstance(float(lng), float), f"Invalid longitude: {lng}"
+        except AssertionError as e:
+            raise ValueError(e)
         if api != "onecall":
             log_deprecation(f"{api} was requested but only `onecall` "
                             f"is supported", "1.0.0")

--- a/neon_api_proxy/services/owm_api.py
+++ b/neon_api_proxy/services/owm_api.py
@@ -32,7 +32,7 @@ from datetime import timedelta
 from requests import Response
 
 from neon_api_proxy.cached_api import CachedAPI
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from neon_utils.authentication_utils import find_neon_owm_key
 
 
@@ -81,8 +81,10 @@ class OpenWeatherAPI(CachedAPI):
 
     def _get_api_response(self, lat: str, lng: str, units: str,
                           api: str = "onecall", lang: str = "en") -> Response:
-        str(float(lat))
-        str(float(lng))
+        if api != "onecall":
+            log_deprecation(f"{api} was requested but only `onecall` "
+                            f"is supported", "1.0.0")
+            api = "onecall"
         assert units in ("metric", "imperial", "standard")
         query_params = {"lat": lat,
                         "lon": lng,
@@ -90,7 +92,7 @@ class OpenWeatherAPI(CachedAPI):
                         "units": units,
                         "lang": lang}
         query_str = urllib.parse.urlencode(query_params)
-        base_url = "http://api.openweathermap.org/data/2.5"
+        base_url = "http://api.openweathermap.org/data/3.0"
         resp = self.get_with_cache_timeout(f"{base_url}/{api}?{query_str}",
                                            self.cache_timeout)
         return resp

--- a/neon_api_proxy/services/wolfram_api.py
+++ b/neon_api_proxy/services/wolfram_api.py
@@ -92,7 +92,7 @@ class WolframAPI(CachedAPI):
         query_params = dict()
         query_params['i'] = kwargs.get("query")
         query_params['units'] = kwargs.get("units") if \
-            kwargs.get("units") == "metric" else "imperial"
+            kwargs.get("units", kwargs.get("unit")) == "metric" else "imperial"
         lat = kwargs.get("lat")
         lng = kwargs.get("lng")
         if kwargs.get("latlong"):

--- a/neon_api_proxy/services/wolfram_api.py
+++ b/neon_api_proxy/services/wolfram_api.py
@@ -92,7 +92,7 @@ class WolframAPI(CachedAPI):
         query_params = dict()
         query_params['i'] = kwargs.get("query")
         query_params['units'] = kwargs.get("units") if \
-            kwargs.get("units", kwargs.get("unit")) == "metric" else "imperial"
+            kwargs.get("units") == "metric" else "imperial"
         lat = kwargs.get("lat")
         lng = kwargs.get("lng")
         if kwargs.get("latlong"):

--- a/neon_api_proxy/services/wolfram_api.py
+++ b/neon_api_proxy/services/wolfram_api.py
@@ -92,7 +92,7 @@ class WolframAPI(CachedAPI):
         query_params = dict()
         query_params['i'] = kwargs.get("query")
         query_params['units'] = kwargs.get("units") if \
-            kwargs.get("units") == "metric" else "nonmetric"
+            kwargs.get("units") == "metric" else "imperial"
         lat = kwargs.get("lat")
         lng = kwargs.get("lng")
         if kwargs.get("latlong"):
@@ -156,6 +156,7 @@ class WolframAPI(CachedAPI):
         :return: dict response containing:
             `status_code`, `content`, and `encoding`
         """
+        LOG.debug(f"query={query}")
         result = self.get_with_cache_timeout(query, timeout=self.cache_time)
         if not result.ok:
             # 501 = Wolfram couldn't understand

--- a/tests/test_wolfram_api.py
+++ b/tests/test_wolfram_api.py
@@ -39,12 +39,12 @@ VALID_QUERY_IP = {"query": "how far away is Moscow?",
                   "ip": "50.47.129.133"}
 
 VALID_QUERY_LAT_LON = {"query": "how far away is new york?",
-                       "units": "nonmetric",
+                       "units": "imperial",
                        "lat": "47.4797",
                        "lng": "122.2079"}
 
 VALID_QUERY_LAT_LON_IP = {"query": "how far away is Bellevue?",
-                          "units": "nonmetric",
+                          "units": "nonmetric",  # Test backwards-compat.
                           "lat": "47.4797",
                           "lng": "122.2079",
                           "ip": "50.47.129.133"}
@@ -86,11 +86,11 @@ class TestWolframAPI(unittest.TestCase):
 
     def test_build_query_string_valid_minimal(self):
         query_str = self.api._build_query_string(**VALID_QUERY_MINIMAL)
-        self.assertEqual(query_str, f"i=how+far+away+is+Miami%3F&units=nonmetric")
+        self.assertEqual(query_str, f"i=how+far+away+is+Miami%3F&units=imperial")
 
     def test_build_query_string_valid_lat_lng(self):
         query_str = self.api._build_query_string(**VALID_QUERY_LAT_LON)
-        self.assertEqual(query_str, f"i=how+far+away+is+new+york%3F&units=nonmetric&latlong=47.4797%2C122.2079")
+        self.assertEqual(query_str, f"i=how+far+away+is+new+york%3F&units=imperial&latlong=47.4797%2C122.2079")
 
     def test_build_query_string_valid_ip(self):
         query_str = self.api._build_query_string(**VALID_QUERY_IP)
@@ -98,7 +98,7 @@ class TestWolframAPI(unittest.TestCase):
 
     def test_build_query_string_valid_lat_lng_ip(self):
         query_str = self.api._build_query_string(**VALID_QUERY_LAT_LON_IP)
-        self.assertEqual(query_str, f"i=how+far+away+is+Bellevue%3F&units=nonmetric&latlong=47.4797%2C122.2079")
+        self.assertEqual(query_str, f"i=how+far+away+is+Bellevue%3F&units=imperial&latlong=47.4797%2C122.2079")
 
     def test_build_query_invalid_query(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
# Description
Update Wolfram|Alpha to use "imperial" instead of "nonmetric" to match API docs
Update OWM to use onecall 3.0 as the latest

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
Weather skill should be updated to stop using the `current` endpoint and make all calls via `onecall`