### PR TITLE
Refactor backend services to accept more configuration params in init

### DIFF
--- a/neon_api_proxy/controller.py
+++ b/neon_api_proxy/controller.py
@@ -71,9 +71,9 @@ class NeonAPIProxyController:
                                   "ngi_auth_vars.yml")
         if isfile(legacy_config_file):
             LOG.warning(f"Legacy configuration found at: {legacy_config_file}")
-            return NGIConfig("ngi_auth_vars").get("api_services", {})
+            return NGIConfig("ngi_auth_vars").get("api_services") or dict()
         else:
-            return Configuration().get("keys", {}).get("api_services", {})
+            return Configuration().get("keys", {}).get("api_services") or dict()
 
     def init_service_instances(self, service_class_mapping: dict) -> dict:
         """
@@ -86,14 +86,14 @@ class NeonAPIProxyController:
         """
         service_mapping = dict()
         for item in service_class_mapping:
-            api_key = self.config.get(item, {}).get("api_key") if self.config \
-                else None
+            service_config = self.config.get(item) or dict()
             try:
-                if api_key is None and item != 'api_test_endpoint':
+                if service_config.get("api_key") is None and item not in \
+                        ('api_test_endpoint', "ip_api"):
                     LOG.warning(f"No API key for {item} in "
                                 f"{list(self.config.keys())}")
                 service_mapping[item] = \
-                    service_class_mapping[item](api_key=api_key)
+                    service_class_mapping[item](**service_config)
             except Exception as e:
                 LOG.error(e)
         return service_mapping

--- a/neon_api_proxy/services/alpha_vantage_api.py
+++ b/neon_api_proxy/services/alpha_vantage_api.py
@@ -48,10 +48,10 @@ class AlphaVantageAPI(CachedAPI):
     API for querying Alpha Vantage.
     """
 
-    def __init__(self, api_key: str = None):
+    def __init__(self, api_key: str = None, cache_seconds: int = 300, **_):
         super().__init__("alpha_vantage")
         self._api_key = api_key or find_neon_alpha_vantage_key()
-        self.quote_timeout = timedelta(minutes=5)
+        self.quote_timeout = timedelta(seconds=cache_seconds)
 
     def _search_symbol(self, query: str) -> dict:
         if not query:

--- a/neon_api_proxy/services/map_maker_api.py
+++ b/neon_api_proxy/services/map_maker_api.py
@@ -42,7 +42,7 @@ class MapMakerAPI(CachedAPI):
     API for querying My Maps API (geocoder.maps.co).
     """
 
-    def __init__(self, api_key: str = None, cache_seconds=604800):  # Cache week
+    def __init__(self, api_key: str = None, cache_seconds: int = 604800, **_):  # Cache week
         super().__init__("map_maker")
         self._api_key = api_key or getenv("MAP_MAKER_KEY")
         if not self._api_key:

--- a/neon_api_proxy/services/owm_api.py
+++ b/neon_api_proxy/services/owm_api.py
@@ -41,7 +41,7 @@ class OpenWeatherAPI(CachedAPI):
     API for querying Open Weather Map.
     """
 
-    def __init__(self, api_key: str = None, cache_seconds=180):
+    def __init__(self, api_key: str = None, cache_seconds: int = 900, **_):
         super().__init__("open_weather_map")
         self._api_key = api_key or find_neon_owm_key()
         self.cache_timeout = timedelta(seconds=cache_seconds)

--- a/neon_api_proxy/services/test_api.py
+++ b/neon_api_proxy/services/test_api.py
@@ -30,7 +30,7 @@ from neon_api_proxy.cached_api import CachedAPI
 
 
 class TestAPI(CachedAPI):
-    def __init__(self, api_key: str = None):
+    def __init__(self, api_key: str = None, **_):
         super().__init__("Test")
 
     def handle_query(self, **kwargs) -> dict:

--- a/neon_api_proxy/services/wolfram_api.py
+++ b/neon_api_proxy/services/wolfram_api.py
@@ -51,11 +51,11 @@ class WolframAPI(CachedAPI):
     API for querying Wolfram|Alpha.
     """
 
-    def __init__(self, api_key: str = None):
+    def __init__(self, api_key: str = None, cache_seconds: int = 3600, **_):
         super().__init__("wolfram")
         self._api_key = api_key or find_neon_wolfram_key()
         self.session.allowable_codes = (200, 501)
-        self.cache_time = timedelta(minutes=60)
+        self.cache_time = timedelta(seconds=cache_seconds)
 
     def _build_query_url(self, query_type: QueryUrl, query_arg: str) -> str:
         """


### PR DESCRIPTION
# Description
Refactors configuration handling to pass arbitrary configuration to backend services instead of just `api_key`
Updates all backend services to use a passed `cache_seconds` kwarg instead of hard-coded values
Updates all backend services to allow arbitrary kwargs to prevent configuration causing init errors and to enable service-specific configuration in the future

# Issues
<!-- If this is related to or closes an issue/other PR, please note them here -->

# Other Notes
<!-- Note any breaking changes, WIP changes, requests for input, etc. here -->