### PR TITLE
Update configuration handling

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Upload cached API test results
         uses: actions/upload-artifact@v4
         with:
-          name: cached-api-test-results
+          name: cached-api-test-results-${{matrix.python-version}}
           path: tests/cached-api-test-results.xml
 
       - name: Test Wolfram API
@@ -65,7 +65,7 @@ jobs:
       - name: Upload Wolfram API test results
         uses: actions/upload-artifact@v4
         with:
-          name: wolfram-api-test-results
+          name: wolfram-api-test-results-${{matrix.python-version}}
           path: tests/wolfram-api-test-results.xml
 
       - name: Test Alpha Vantage API
@@ -74,7 +74,7 @@ jobs:
       - name: Upload Alpha Vantage API test results
         uses: actions/upload-artifact@v4
         with:
-          name: alphavantage-api-test-results
+          name: alphavantage-api-test-results-${{matrix.python-version}}
           path: tests/alphavantage-api-test-results.xml
 
       - name: Test OWM API
@@ -83,7 +83,7 @@ jobs:
       - name: Upload Open Weather Map API test results
         uses: actions/upload-artifact@v4
         with:
-          name: owm-api-test-results
+          name: owm-api-test-results-${{matrix.python-version}}
           path: tests/owm-api-test-results.xml
 
       - name: Test Map Maker API
@@ -94,7 +94,7 @@ jobs:
       - name: Upload Map Maker API test results
         uses: actions/upload-artifact@v4
         with:
-          name: map-maker-api-test-results
+          name: map-maker-api-test-results-${{matrix.python-version}}
           path: tests/map-maker-api-test-results.xml
 
       - name: Test Generic API
@@ -103,5 +103,5 @@ jobs:
       - name: Upload Generic API test results
         uses: actions/upload-artifact@v4
         with:
-          name: generic-controller-test-results
+          name: generic-controller-test-results-${{matrix.python-version}}
           path: tests/generic-controller-test-results.xml

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           pytest tests/test_cached_api.py --doctest-modules --junitxml=tests/cached-api-test-results.xml
       - name: Upload cached API test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: cached-api-test-results
           path: tests/cached-api-test-results.xml
@@ -63,7 +63,7 @@ jobs:
         run: |
           pytest tests/test_wolfram_api.py --doctest-modules --junitxml=tests/wolfram-api-test-results.xml
       - name: Upload Wolfram API test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: wolfram-api-test-results
           path: tests/wolfram-api-test-results.xml
@@ -72,7 +72,7 @@ jobs:
         run: |
           pytest tests/test_alpha_vantage_api.py --doctest-modules --junitxml=tests/alphavantage-api-test-results.xml
       - name: Upload Alpha Vantage API test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: alphavantage-api-test-results
           path: tests/alphavantage-api-test-results.xml
@@ -81,7 +81,7 @@ jobs:
         run: |
           pytest tests/test_owm_api.py --doctest-modules --junitxml=tests/owm-api-test-results.xml
       - name: Upload Open Weather Map API test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: owm-api-test-results
           path: tests/owm-api-test-results.xml
@@ -92,7 +92,7 @@ jobs:
         env:
           MAP_MAKER_KEY: ${{secrets.map_maker_key}}
       - name: Upload Map Maker API test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: map-maker-api-test-results
           path: tests/map-maker-api-test-results.xml
@@ -101,7 +101,7 @@ jobs:
         run: |
           pytest tests/test_generic_controller.py --doctest-modules --junitxml=tests/generic-controller-test-results.xml
       - name: Upload Generic API test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: generic-controller-test-results
           path: tests/generic-controller-test-results.xml

--- a/neon_api_proxy/controller.py
+++ b/neon_api_proxy/controller.py
@@ -71,7 +71,9 @@ class NeonAPIProxyController:
                                   "ngi_auth_vars.yml")
         if isfile(legacy_config_file):
             log_deprecation(f"Legacy configuration found at: {legacy_config_file}. "
-                            f"This will be ignored in future versions.",
+                            f"This will be ignored in future versions. "
+                            f"Default configuration handling will use "
+                            f"~/.config/neon/diana.yaml.",
                             "1.0.0")
             return NGIConfig("ngi_auth_vars").get("api_services") or dict()
         else:

--- a/neon_api_proxy/controller.py
+++ b/neon_api_proxy/controller.py
@@ -27,7 +27,7 @@
 # SOFTWARE,  EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 from os.path import join, isfile
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_config.config import Configuration
 from neon_utils.configuration_utils import NGIConfig
 from ovos_config.locations import get_xdg_config_save_path
@@ -70,10 +70,14 @@ class NeonAPIProxyController:
         legacy_config_file = join(get_xdg_config_save_path(),
                                   "ngi_auth_vars.yml")
         if isfile(legacy_config_file):
-            LOG.warning(f"Legacy configuration found at: {legacy_config_file}")
+            log_deprecation(f"Legacy configuration found at: {legacy_config_file}. "
+                            f"This will be ignored in future versions.",
+                            "1.0.0")
             return NGIConfig("ngi_auth_vars").get("api_services") or dict()
         else:
-            return Configuration().get("keys", {}).get("api_services") or dict()
+            config = Configuration()
+            return config.get("keys", {}).get("api_services") or \
+                config.get("api_services") or dict()
 
     def init_service_instances(self, service_class_mapping: dict) -> dict:
         """


### PR DESCRIPTION
# Description
Update warning log to use log_deprecation
Update config handling to support `api_services` config outside of `keys` since #98 enabled more configuration options

# Issues
Continues config options added in #98 

# Other Notes
This leaves backwards-compat for config but allows configuring `api_services` outside of `keys` configuration since config may contain more options than keys now. i.e.:

```yaml
api_services:
  wolfram_alpha:
    api_key: KEY
    cache_timeout: 300
```